### PR TITLE
feat: create type Ref's extension `DebounceAndCancelExtension`. Imple…

### DIFF
--- a/lib/core/extensions/ref_debounce_and_cancel.dart
+++ b/lib/core/extensions/ref_debounce_and_cancel.dart
@@ -1,0 +1,19 @@
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:http/http.dart' as http;
+
+extension DebounceAndCancelExtension on Ref {
+  Future<http.Client> getCleanClient() async {
+    final client = http.Client();
+
+    var disposed = false;
+    onDispose(() {
+      disposed = true;
+      client.close();
+    });
+
+    if (disposed) throw Exception('Client disposed');
+    await Future.delayed(Duration(seconds: 1));
+
+    return client;
+  }
+}

--- a/lib/providers/quote/quote_provider.dart
+++ b/lib/providers/quote/quote_provider.dart
@@ -1,18 +1,18 @@
 import 'dart:convert';
 
+import 'package:fitcker/core/extensions/ref_debounce_and_cancel.dart';
 import 'package:fitcker/models/quote/quote.dart';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
-import 'package:http/http.dart' as http;
 
 part 'quote_provider.g.dart';
 
 @riverpod
 Future<Quote> getQuote(Ref ref) async {
   final url = Uri.parse('https://quotes-api-self.vercel.app/quote');
-  final response = await http.get(url);
-
+  final client = await ref.getCleanClient();
+  final response = await client.get(url);
   if (response.statusCode == 200) {
     final body = jsonDecode(response.body) as Map<String, dynamic>;
     return Quote.fromJson(body);


### PR DESCRIPTION
## Feat: Add Riverpod Ref Extension for Debounced and Auto-Disposing HTTP Client

**Description:**

This pull request introduces a Dart extension named `DebounceAndCancelExtension` on Riverpod's `Ref` object. This extension provides a utility method, `getCleanClient()`, designed to return an `http.Client` instance that incorporates a short delay (debounce) and ensures the client is automatically closed when the associated Riverpod provider is disposed.

**Key Features & Implementation Details:**

*   **`DebounceAndCancelExtension` on `Ref`:**
    *   An extension is defined on `Ref` to make the new utility easily accessible within Riverpod providers.
*   **`getCleanClient()` Method:**
    *   **Client Creation:** Creates a new `http.Client` instance.
    *   **Automatic Disposal:**
        *   Uses `ref.onDispose()` to register a callback that closes the `http.Client` when the provider is disposed.
        *   Includes a check to prevent using the client if it has already been disposed, throwing an exception in such cases.
    *   **Debounce/Delay:**
        *   Introduces a `Future.delayed(Duration(seconds: 1))` before returning the client. This might be intended as a simple debounce mechanism or to prevent rapid, successive client creations/requests under certain conditions.
    *   **Return Value:** Returns a `Future<http.Client>`, meaning callers will need to `await` this method.

**Purpose & Benefits:**

*   **Resource Management:** Automatically closes the `http.Client`, helping to prevent resource leaks that can occur if clients are not properly disposed of.
*   **Simplified Client Handling in Providers:** Abstracts away the boilerplate of creating a client and setting up `onDispose` for each provider that needs an HTTP client.
*   **Request Throttling (Implicit):** The 1-second delay might serve as a basic form of request throttling or debouncing, potentially preventing an excessive number of requests in a short period if the provider rebuilds frequently.

**How to Test:**

1.  **Client Creation and Usage:**
    *   Create a Riverpod provider (e.g., a `FutureProvider` or `StreamProvider`) that uses `await ref.getCleanClient()` to obtain an `http.Client`.
    *   Use this client to make a successful HTTP request.
    *   **Verify:** The request is successful, and data is fetched as expected.
2.  **Automatic Disposal:**
    *   In a test environment or using debugging tools:
        *   Cause the provider using `getCleanClient()` to be disposed (e.g., by navigating away from a screen that uses it, if `autoDispose` is configured, or by directly invalidating/disposing of the provider in a test).
        *   **Verify:** The `client.close()` method is called on the `http.Client` instance associated with that provider. (This might require adding logging within the `onDispose` callback in the extension for verification, or using mock clients that can track method calls).
3.  **Usage After Disposal (Error Handling):**
    *   Attempt to call `ref.getCleanClient()` on a `Ref` instance that has already been disposed (this might be tricky to set up reliably outside of specific test scenarios).
    *   Or, after a provider is disposed, if one could somehow still get a reference to the old client instance and try to use it (though the extension aims to prevent this by throwing).
    *   **Verify:** The intended exception ("Client disposed") is thrown if an attempt is made to get or use a client after its associated `Ref` has been disposed and the client closed.
4.  **Debounce/Delay Behavior:**
    *   Call `ref.getCleanClient()` and measure the time until the `Future` completes.
    *   **Verify:** There is approximately a 1-second delay before the client is returned.

**Considerations & Potential Discussion Points:**

*   **Debounce Logic:** The current 1-second delay is a fixed debounce. Depending on the use case, a more sophisticated debouncing strategy (e.g., cancellable timers, only delaying subsequent calls within a window) might be needed. This PR implements a simple delay.
*   **Error Handling:** The extension throws a generic `Exception('Client disposed')`. Consider if a more specific exception type would be beneficial.
*   **Use Cases:** Clarify or document the primary scenarios where this specific debounced and auto-disposing client is most useful.

**Context:**

This utility extension aims to simplify HTTP client management within Riverpod providers by providing a convenient way to obtain an `http.Client` that is automatically cleaned up and includes a basic request delay.