### PR TITLE
Feat/auth guard

### DIFF
--- a/lib/core/configs/router_configs/redirection.dart
+++ b/lib/core/configs/router_configs/redirection.dart
@@ -1,0 +1,38 @@
+part of 'router.dart';
+
+FutureOr<String?> handleRedirect(
+  BuildContext context,
+  GoRouterState state,
+  Ref ref,
+) {
+  final isSignIn = state.matchedLocation == '/sign-in';
+  final isSignUp = state.matchedLocation == '/sign-up';
+  final isOnboarding = state.matchedLocation == '/onboarding';
+  if (isSignIn || isSignUp || isOnboarding) {
+    return null;
+  }
+
+  // check if user has seen the onboarding screen
+  final hasSeenOnboarding = _hasSeenOnboarding(ref);
+  if (!hasSeenOnboarding) {
+    return '/onboarding';
+  }
+
+  // check if user is logged in or not
+  final isAuthenticated = _isAuthenticated(ref);
+  if (!isAuthenticated) {
+    // user can access any route
+    return '/sign-in';
+  }
+  return null;
+}
+
+bool _hasSeenOnboarding(Ref<Object?> ref) {
+  final hasSeenOnboarding = ref.read(hasSeenOnboardingProvider);
+  return hasSeenOnboarding;
+}
+
+bool _isAuthenticated(Ref<Object?> ref) {
+  final user = ref.read(authNotifierProvider);
+  return user?.isAuthenticated == true;
+}

--- a/lib/core/configs/router_configs/router.dart
+++ b/lib/core/configs/router_configs/router.dart
@@ -1,4 +1,8 @@
+import 'dart:async';
+
 import 'package:fitcker/core/configs/router_configs/route_names.dart';
+import 'package:fitcker/providers/auth/auth_provider.dart';
+import 'package:fitcker/providers/onboarding/onboarding_provider.dart';
 import 'package:fitcker/screens/main_screen.dart';
 import 'package:fitcker/screens/onboarding_screen.dart';
 import 'package:fitcker/screens/profile_screen.dart';
@@ -8,12 +12,17 @@ import 'package:fitcker/screens/workout_list_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+part 'redirection.dart';
 
 final routeProvider = Provider((ref) {
   return GoRouter(
-    initialLocation: RouteNames.signIn,
+    initialLocation: '/workout-list',
     errorBuilder: (context, state) {
       return const Scaffold(body: Center(child: Text('Page not found')));
+    },
+    redirect: (context, state) {
+      final redirect = handleRedirect(context, state, ref);
+      return redirect;
     },
     debugLogDiagnostics: true,
     routes: [

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,10 +27,6 @@ class MyApp extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, ref) {
-    // TODO: implement Auth Guard
-    // final hasOnboardingSeen = ref.read(hasSeenOnboardingProvider);
-    // final user = ref.watch(authNotifierProvider);
-
     final router = ref.watch(routeProvider);
     return MaterialApp.router(
       title: 'Fitcker',

--- a/lib/screens/onboarding_screen.dart
+++ b/lib/screens/onboarding_screen.dart
@@ -43,7 +43,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
 
   void _onDone(BuildContext context) async {
     await _changeOnboardingInitializedState();
-    if (mounted) {
+    if (context.mounted) {
       context.pushNamed(RouteNames.signUp);
     }
   }

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,5 +1,7 @@
+import 'package:fitcker/core/configs/router_configs/route_names.dart';
 import 'package:fitcker/models/workout/workout.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 
 import '../providers/auth/auth_provider.dart';
@@ -8,7 +10,6 @@ import 'edit_profile_screen.dart';
 import 'help_support_screen.dart';
 import 'notifications_screen.dart';
 import 'settings_screen.dart';
-import 'sign_in_screen.dart';
 
 class ProfileScreen extends HookConsumerWidget {
   const ProfileScreen({super.key});
@@ -16,12 +17,7 @@ class ProfileScreen extends HookConsumerWidget {
   Future<void> _signOut(BuildContext context, WidgetRef ref) async {
     await ref.read(authNotifierProvider.notifier).signOut();
     if (context.mounted) {
-      Navigator.of(context).pushAndRemoveUntil(
-        MaterialPageRoute(
-          builder: (context) => const SignInScreen(),
-        ),
-        (route) => false,
-      );
+      context.goNamed(RouteNames.signIn);
     }
   }
 
@@ -152,9 +148,7 @@ class ProfileScreen extends HookConsumerWidget {
                         ),
                         title: Text(
                           'Sign Out',
-                          style: TextStyle(
-                            color: theme.colorScheme.secondary,
-                          ),
+                          style: TextStyle(color: theme.colorScheme.secondary),
                         ),
                       ),
                     ],
@@ -173,16 +167,12 @@ class ProfileScreen extends HookConsumerWidget {
 class _StatsRow extends StatelessWidget {
   final List<Workout> workouts;
 
-  const _StatsRow({
-    required this.workouts,
-  });
+  const _StatsRow({required this.workouts});
 
   @override
   Widget build(BuildContext context) {
-    final completedWorkouts =
-        workouts.where((w) => w.isCompleted).length;
-    final inProgressWorkouts =
-        workouts.where((w) => !w.isCompleted).length;
+    final completedWorkouts = workouts.where((w) => w.isCompleted).length;
+    final inProgressWorkouts = workouts.where((w) => !w.isCompleted).length;
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 32.0),
@@ -232,10 +222,7 @@ class _StatItem extends StatelessWidget {
             color: theme.colorScheme.surface,
             shape: BoxShape.circle,
           ),
-          child: Icon(
-            icon,
-            color: theme.colorScheme.primary,
-          ),
+          child: Icon(icon, color: theme.colorScheme.primary),
         ),
         const SizedBox(height: 8),
         Text(
@@ -271,13 +258,8 @@ class _ProfileMenuItem extends StatelessWidget {
     final theme = Theme.of(context);
     return ListTile(
       onTap: onTap,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-      ),
-      leading: Icon(
-        icon,
-        color: theme.colorScheme.primary,
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      leading: Icon(icon, color: theme.colorScheme.primary),
       title: Text(title),
       trailing: const Icon(Icons.chevron_right),
     );

--- a/lib/screens/sign_in_screen.dart
+++ b/lib/screens/sign_in_screen.dart
@@ -64,7 +64,7 @@ class SignInScreen extends HookConsumerWidget {
           .signIn(emailController.text, passwordController.text);
 
       if (success && context.mounted) {
-        context.pushNamed(RouteNames.workoutList);
+        context.goNamed(RouteNames.workoutList);
       } else if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(

--- a/lib/screens/sign_up_screen.dart
+++ b/lib/screens/sign_up_screen.dart
@@ -228,7 +228,7 @@ class SignUpScreen extends HookConsumerWidget {
                     const SizedBox(height: 16),
                     TextButton(
                       onPressed: () {
-                        context.pushNamed(RouteNames.signIn);
+                        context.goNamed(RouteNames.signIn);
                       },
                       child: Text.rich(
                         TextSpan(

--- a/lib/widgets/app_button.dart
+++ b/lib/widgets/app_button.dart
@@ -33,6 +33,9 @@ class AppButton extends HookWidget {
                 if (onPressed != null) {
                   await onPressed!();
                 }
+                if (context.mounted) {
+                  return;
+                }
                 isLoading.value = false;
               },
         style: FilledButton.styleFrom(


### PR DESCRIPTION
## Feat: Implement Auth & Onboarding Redirect Logic in GoRouter and Refactor Navigation

**Description:**

This pull request introduces sophisticated redirect logic within `GoRouter` to manage user navigation based on their onboarding completion status and authentication state. It also includes several code refactorings, such as removing TODOs, adding `mounted` checks for context safety, and migrating more navigation calls to use `go_router`'s named routes.

**Key Features & Changes:**

*   **Router Redirect Logic (`redirection.dart`):**
    *   A new file, `redirection.dart`, has been created as a part of `router.dart` (likely using a `part of` directive).
    *   This file implements the core redirect logic for `GoRouter`.
    *   **Onboarding Check:** It first checks if the user has completed the onboarding process (e.g., by checking a value in `SharedPreferences` via a Riverpod provider).
        *   If onboarding is not complete, and the user is not already on an onboarding-related screen, they are redirected to the onboarding screen.
    *   **Authentication Check:** If onboarding is complete, it then checks the user's authentication status (e.g., via an auth provider).
        *   If the user is not authenticated and is trying to access a protected route, they are redirected to a sign-in screen.
        *   If authenticated, or accessing public routes, navigation proceeds as requested (or to a default authenticated screen).
    *   This logic ensures users are guided to the appropriate starting point in the app based on their current state (`feat: create redirection.dart...`).
*   **Navigation Refactoring & Improvements:**
    *   Navigation calls in `sign_up_screen.dart`, `sign_in_screen.dart`, and `profile_screen.dart` have been updated from `Navigator.pushNamed` to `context.goNamed` (or `context.pushNamed` if appropriate within `go_router`'s context), aligning with the `go_router` methodology (`refactor: ...replace pushNamed by goNamed...`).
*   **Code Quality Enhancements:**
    *   A `//TODO` comment has been removed from `main.dart`, indicating a task completion or cleanup (`refactor: 1 - remove //TODO from main.dart...`).
    *   `if (context.mounted)` checks have been added in `onboard_screen.dart` and `app_button.dart` before using the `BuildContext` in asynchronous operations. This is a good practice to prevent errors if the widget is removed from the tree before the async operation completes (`refactor: ...2 - check if (context.mounted)...`).

**How to Test:**

1.  **Onboarding Redirect Logic:**
    *   **New User (Onboarding Not Seen):**
        *   Clear app data (or simulate a new user state where onboarding is not marked as completed).
        *   Launch the app and attempt to navigate to a protected route (e.g., `/home`) or the root `/`.
        *   **Verify:** The user is redirected to the onboarding screen.
        *   Navigate directly to `/sign-in` or `/sign-up`.
        *   **Verify:** Access to these specific routes is allowed even if onboarding is not complete (as per typical redirect logic which usually bypasses auth/onboarding checks for these explicit destinations).
    *   **User Has Seen Onboarding:**
        *   Complete the onboarding process (so it's marked as seen).
        *   Close and relaunch, or attempt to navigate to `/onboarding`.
        *   **Verify:** The user is *not* redirected to onboarding again and proceeds to the next check (authentication) or their intended destination if not `/onboarding`.
2.  **Authentication Redirect Logic (After Onboarding is Seen):**
    *   **Unauthenticated User:**
        *   Ensure onboarding is marked as complete.
        *   Ensure the user is logged out.
        *   Attempt to navigate to a protected route (e.g., `/profile`, `/workout-list`).
        *   **Verify:** The user is redirected to the sign-in screen (`/sign-in`).
    *   **Authenticated User:**
        *   Ensure onboarding is marked as complete.
        *   Log in as a user.
        *   Attempt to navigate to `/sign-in` or `/sign-up`.
        *   **Verify:** The user might be redirected away from sign-in/sign-up to a main app screen (common behavior, depends on your exact redirect rules if an authenticated user tries to access auth pages).
        *   Navigate to protected routes.
        *   **Verify:** Access is granted.
3.  **Navigation with `goNamed`:**
    *   Trigger navigation from `sign_up_screen.dart`, `sign_in_screen.dart`, and `profile_screen.dart`.
    *   **Verify:** Navigation works correctly using `goNamed` to the intended destinations.
4.  **`context.mounted` Checks:**
    *   For `onboard_screen.dart` and `app_button.dart`, if there are async operations followed by `context` usage:
        *   Try to trigger a scenario where the widget might be disposed before the async operation completes (e.g., quickly navigate away after initiating the action). This can be hard to reliably test manually but review the code to ensure the check is placed correctly.
        *   **Verify (Code Review):** The `if (context.mounted)` check correctly guards `BuildContext` usage after an `await`.
5.  **No Regressions:**
    *   Perform general app navigation and functionality checks to ensure no regressions were introduced.

**Context:**

This PR significantly improves the user flow by implementing intelligent routing redirects based on onboarding and authentication status, ensuring users always land on the appropriate screen. The accompanying refactorings enhance code robustness and maintain consistency with the `go_router` navigation paradigm. This is a crucial step for a polished user experience.